### PR TITLE
feat: prevent video download in course videos

### DIFF
--- a/apps/web/components/community/index.tsx
+++ b/apps/web/components/community/index.tsx
@@ -654,6 +654,8 @@ export function CommunityForum({
                             poster={media.media.thumbnail}
                             className="h-48 aspect-video object-cover rounded-md"
                             controls
+                            controlsList="nodownload" // eslint-disable-line react/no-unknown-property
+                            onContextMenu={(e) => e.preventDefault()}
                         >
                             Your browser does not support the video tag.
                         </video>

--- a/apps/web/components/public/lesson-viewer/index.tsx
+++ b/apps/web/components/public/lesson-viewer/index.tsx
@@ -225,6 +225,7 @@ const LessonViewer = ({
                                 <video
                                     controls
                                     controlsList="nodownload" // eslint-disable-line react/no-unknown-property
+                                    onContextMenu={(e) => e.preventDefault()}
                                     key={lesson.lessonId}
                                     className="w-full rounded mb-2"
                                 >
@@ -254,6 +255,7 @@ const LessonViewer = ({
                                 <audio
                                     controls
                                     controlsList="nodownload" // eslint-disable-line react/no-unknown-property
+                                    onContextMenu={(e) => e.preventDefault()}
                                 >
                                     <source
                                         src={

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -82,3 +82,43 @@
         @apply bg-background text-foreground;
     }
 }
+
+/* Video protection styles - works without JavaScript */
+@layer utilities {
+    video {
+        /* Disable right-click context menu */
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        /* Disable drag and drop */
+        -webkit-user-drag: none;
+        -khtml-user-drag: none;
+        -moz-user-drag: none;
+        -o-user-drag: none;
+        user-drag: none;
+        /* Disable highlighting */
+        -webkit-tap-highlight-color: transparent;
+        /* Disable outline */
+        outline: none;
+    }
+
+    audio {
+        /* Same protection for audio elements */
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        -webkit-user-drag: none;
+        -khtml-user-drag: none;
+        -moz-user-drag: none;
+        -o-user-drag: none;
+        user-drag: none;
+        -webkit-tap-highlight-color: transparent;
+        outline: none;
+    }
+}

--- a/packages/components-library/src/video-with-preview.tsx
+++ b/packages/components-library/src/video-with-preview.tsx
@@ -237,6 +237,8 @@ export function VideoWithPreview({
                             <video
                                 src={videoUrl}
                                 controls
+                                controlsList="nodownload" // eslint-disable-line react/no-unknown-property
+                                onContextMenu={(e) => e.preventDefault()}
                                 autoPlay
                                 className="w-full h-full"
                             >
@@ -301,6 +303,8 @@ export function VideoWithPreview({
                             <video
                                 src={videoUrl}
                                 controls
+                                controlsList="nodownload" // eslint-disable-line react/no-unknown-property
+                                onContextMenu={(e) => e.preventDefault()}
                                 autoPlay
                                 className="w-full h-full"
                             >


### PR DESCRIPTION
- Add controlsList='nodownload' attribute to all video/audio elements
- Implement onContextMenu prevention to disable right-click context menu
- Add CSS-based protection for user selection and drag prevention
- Apply protections across lesson viewer, community posts, and video components
- Ensure protection works even when JavaScript is disabled (partial)

This prevents users from easily downloading course videos through:
- Browser's built-in video controls download button
- Right-click context menu 'Save video as' option
- Drag and drop video element downloading

Files modified:
- apps/web/components/public/lesson-viewer/index.tsx
- apps/web/components/community/index.tsx
- packages/components-library/src/video-with-preview.tsx
- apps/web/styles/globals.css