### PR TITLE
fix: Add 'None' option to payment method dropdown to allow resetting payment config

### DIFF
--- a/apps/web/components/admin/settings/index.tsx
+++ b/apps/web/components/admin/settings/index.tsx
@@ -814,6 +814,10 @@ const Settings = (props: SettingsProps) => {
                             }
                             options={[
                                 {
+                                    label: SITE_SETTINGS_PAYMENT_METHOD_NONE_LABEL,
+                                    value: PAYMENT_METHOD_NONE,
+                                },
+                                {
                                     label: capitalize(
                                         PAYMENT_METHOD_STRIPE.toLowerCase(),
                                     ),
@@ -856,9 +860,6 @@ const Settings = (props: SettingsProps) => {
                                         paymentMethod: value,
                                     }),
                                 )
-                            }
-                            placeholderMessage={
-                                SITE_SETTINGS_PAYMENT_METHOD_NONE_LABEL
                             }
                             disabled={!newSettings.currencyISOCode}
                         />


### PR DESCRIPTION
Fixes #583

## Description
This PR adds a 'None' option to the payment method dropdown on the  screen, allowing users to reset their payment configuration.

## Changes
- Added `PAYMENT_METHOD_NONE` as the first option in the payment method dropdown
- Removed `placeholderMessage` prop since 'None' is now a selectable option
- Users can now explicitly select 'None' to reset their payment configuration

## Testing
- The 'None' option appears as the first item in the payment method dropdown
- Selecting 'None' properly resets the payment method
- The change maintains backward compatibility with existing configurations

## Related Issue
Closes #583