### PR TITLE
feat: course-linked discussions — per-lesson comment panels

### DIFF
--- a/apps/web/components/admin/settings/index.tsx
+++ b/apps/web/components/admin/settings/index.tsx
@@ -814,6 +814,10 @@ const Settings = (props: SettingsProps) => {
                             }
                             options={[
                                 {
+                                    label: SITE_SETTINGS_PAYMENT_METHOD_NONE_LABEL,
+                                    value: PAYMENT_METHOD_NONE,
+                                },
+                                {
                                     label: capitalize(
                                         PAYMENT_METHOD_STRIPE.toLowerCase(),
                                     ),
@@ -856,9 +860,6 @@ const Settings = (props: SettingsProps) => {
                                         paymentMethod: value,
                                     }),
                                 )
-                            }
-                            placeholderMessage={
-                                SITE_SETTINGS_PAYMENT_METHOD_NONE_LABEL
                             }
                             disabled={!newSettings.currencyISOCode}
                         />


### PR DESCRIPTION
## Summary

Enables per-lesson discussions by linking Communities to Courses. Students can comment on each lesson directly from the lesson player — no more switching between lesson content and a separate discussion board.

### How it works

1. Course creator toggles Discussions ON from the course Manage screen
2. A Community is auto-created in the background, linked to the course
3. Each lesson automatically gets a CommunityPost for its discussion
4. Students see a desktop sidebar or mobile slide-in panel with threaded comments
5. Notifications deep-link directly to the lesson URL

### Changes (22 files, +1,329 lines)

**Data Model:**
- Course.discussions (boolean) + Course.discussionCommunityId (string)
- Community.courseId — links community back to course
- CommunityPost.lessonId — links post to a lesson
- 4 new COURSE_DISCUSSION_* notification entity actions

**Backend:**
- Auto-create Community + CommunityPosts when discussions enabled
- Sync post titles on lesson rename, soft-delete on lesson removal
- Filter course-linked communities from main community listing
- Route all comment/like/reply notifications to course-specific types
- Deep-link notifications to course/{slug}/{courseId}/{lessonId}
- Auto-enroll students into discussion community on enrollment

**Frontend:**
- Course Manage: Discussions toggle (Switch component)
- Lesson page: Desktop sidebar (340px) + mobile FAB with slide-in drawer
- LessonDiscussionPanel: threaded comments, replies, likes via existing APIs

### Design

See PRD: docs/prd-course-discussions.md