### PR TITLE
fix: add missing await to reCAPTCHA validation in checkout login form

### DIFF
--- a/apps/web/app/(with-contexts)/(with-layout)/login/login-form.tsx
+++ b/apps/web/app/(with-contexts)/(with-layout)/login/login-form.tsx
@@ -175,7 +175,7 @@ export default function LoginForm({
         setLoading(true);
         setError("");
 
-        if (!validateRecaptcha()) {
+        if (!(await validateRecaptcha())) {
             return;
         }
 

--- a/apps/web/components/public/payments/login-form.tsx
+++ b/apps/web/components/public/payments/login-form.tsx
@@ -158,7 +158,7 @@ export function LoginForm({
     const requestCode = async function (email: string) {
         setLoading(true);
 
-        if (!validateRecaptcha()) {
+        if (!(await validateRecaptcha())) {
             return;
         }
 


### PR DESCRIPTION

## Fix
Adds missing `await` keyword before `validateRecaptcha()` calls in both:
1. The checkout login form (`apps/web/components/public/payments/login-form.tsx`)
2. The main login form (`apps/web/app/(with-contexts)/(with-layout)/login/login-form.tsx`)

## Problem
The `validateRecaptcha()` function is `async` and returns a `Promise<boolean>`, but was called without `await`. Since a Promise object is always truthy, `!Promise` is always `false`, meaning the reCAPTCHA check was **silently bypassed** even when reCAPTCHA env vars were configured.

## Testing
- Tests for the checkout login form pass
- Lint passes
- Prettier passes

Fixes #688
